### PR TITLE
carousel change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,14 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.24.1",
-        "react-swipeable-views-react-18-fix": "^0.14.1"
+        "react-slick": "^0.30.2",
+        "react-swipeable-views-react-18-fix": "^0.14.1",
+        "slick-carousel": "^1.8.1"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
+        "@types/react-slick": "^0.23.13",
         "@typescript-eslint/eslint-plugin": "^7.13.1",
         "@typescript-eslint/parser": "^7.13.1",
         "@vitejs/plugin-react": "^4.3.1",
@@ -1716,6 +1719,15 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-slick": {
+      "version": "0.23.13",
+      "resolved": "https://registry.npmjs.org/@types/react-slick/-/react-slick-0.23.13.tgz",
+      "integrity": "sha512-bNZfDhe/L8t5OQzIyhrRhBr/61pfBcWaYJoq6UDqFtv5LMwfg4NsVDD2J8N01JqdAdxLjOt66OZEp6PX+dGs/A==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/react-transition-group": {
       "version": "4.4.10",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
@@ -2135,6 +2147,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2281,6 +2298,11 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.818.tgz",
       "integrity": "sha512-eGvIk2V0dGImV9gWLq8fDfTTsCAeMDwZqEPMr+jMInxZdnp9Us8UpovYpRCf9NQ7VOFgrN2doNSgvISbsbNpxA==",
       "dev": true
+    },
+    "node_modules/enquire.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
+      "integrity": "sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw=="
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -3051,6 +3073,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "peer": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3101,6 +3129,14 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "dependencies": {
+        "string-convert": "^0.2.0"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -3160,6 +3196,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -3580,6 +3621,22 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-slick": {
+      "version": "0.30.2",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.30.2.tgz",
+      "integrity": "sha512-XvQJi7mRHuiU3b9irsqS9SGIgftIfdV5/tNcURTb5LdIokRA5kIIx3l4rlq2XYHfxcSntXapoRg/GxaVOM1yfg==",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "enquire.js": "^2.1.6",
+        "json2mq": "^0.2.0",
+        "lodash.debounce": "^4.0.8",
+        "resize-observer-polyfill": "^1.5.0"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-swipeable-views-core-react-18-fix": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-swipeable-views-core-react-18-fix/-/react-swipeable-views-core-react-18-fix-0.14.0.tgz",
@@ -3719,6 +3776,11 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -3883,6 +3945,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/slick-carousel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
+      "peerDependencies": {
+        "jquery": ">=1.8.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -3899,6 +3969,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A=="
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,14 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.24.1",
-    "react-swipeable-views-react-18-fix": "^0.14.1"
+    "react-slick": "^0.30.2",
+    "react-swipeable-views-react-18-fix": "^0.14.1",
+    "slick-carousel": "^1.8.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@types/react-slick": "^0.23.13",
     "@typescript-eslint/eslint-plugin": "^7.13.1",
     "@typescript-eslint/parser": "^7.13.1",
     "@vitejs/plugin-react": "^4.3.1",

--- a/src/componentes/Carrusel.tsx
+++ b/src/componentes/Carrusel.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { useTheme } from '@mui/material/styles';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import KeyboardArrowLeft from '@mui/icons-material/KeyboardArrowLeft';
-import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight';
-import SwipeableViews from 'react-swipeable-views-react-18-fix';
+import Slider from 'react-slick';
+import "slick-carousel/slick/slick.css";
+import "slick-carousel/slick/slick-theme.css";
+import { KeyboardArrowLeft, KeyboardArrowRight } from '@mui/icons-material';
 
 interface Image {
   imgPath: string;
@@ -14,21 +13,62 @@ interface CarruselProps {
   images: Image[];
 }
 
+const NextArrow = (props: any) => {
+  const { className, style, onClick } = props;
+  return (
+    <div
+      className={className}
+      style={{
+        ...style,
+        display: 'block',
+        background: 'rgba(250, 250, 250, 0.2)',
+        borderRadius: '50%',
+        right: 10,
+        zIndex: 1,
+      }}
+      onClick={onClick}
+    >
+      <KeyboardArrowRight />
+    </div>
+  );
+};
+
+const PrevArrow = (props: any) => {
+  const { className, style, onClick } = props;
+  return (
+    <div
+      className={className}
+      style={{
+        ...style,
+        display: 'block',
+        background: 'rgba(250, 250, 250, 0.2)',
+        borderRadius: '50%',
+        left: 10,
+        zIndex: 1,
+      }}
+      onClick={onClick}
+    >
+      <KeyboardArrowLeft />
+    </div>
+  );
+};
+
 const Carrusel: React.FC<CarruselProps> = ({ images }) => {
-  const theme = useTheme();
   const [activeStep, setActiveStep] = React.useState(0);
-  const maxSteps = images.length;
 
-  const handleNext = () => {
-    setActiveStep((prevActiveStep) => prevActiveStep + 1);
+  const handleStepChange = (index: number) => {
+    setActiveStep(index);
   };
 
-  const handleBack = () => {
-    setActiveStep((prevActiveStep) => prevActiveStep - 1);
-  };
-
-  const handleStepChange = (step: number) => {
-    setActiveStep(step);
+  const settings = {
+    dots: true,
+    infinite: true,
+    speed: 500,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+    beforeChange: (_current: number, next: number) => handleStepChange(next),
+    nextArrow: <NextArrow />,
+    prevArrow: <PrevArrow />,
   };
 
   return (
@@ -42,62 +82,25 @@ const Carrusel: React.FC<CarruselProps> = ({ images }) => {
           margin: '0 auto',
         }}
       >
-        <SwipeableViews
-          axis={theme.direction === 'rtl' ? 'x-reverse' : 'x'}
-          index={activeStep}
-          onChangeIndex={handleStepChange}
-          enableMouseEvents
-        >
+        <Slider {...settings}>
           {images.map((step, index) => (
             <div key={index}>
-              {Math.abs(activeStep - index) <= 2 ? (
-                <Box
-                  component="img"
-                  sx={{
-                    height: 140,
-                    display: 'block',
-                    maxWidth: 345,
-                    overflow: 'hidden',
-                    width: '100%',
-                    objectFit: 'cover',
-                  }}
-                  src={step.imgPath}
-                  alt={`Image ${index + 1}`}
-                />
-              ) : null}
+              <Box
+                component="img"
+                sx={{
+                  height: 140,
+                  display: 'block',
+                  maxWidth: 345,
+                  overflow: 'hidden',
+                  width: '100%',
+                  objectFit: 'cover',
+                }}
+                src={step.imgPath}
+                alt={`Image ${index + 1}`}
+              />
             </div>
           ))}
-        </SwipeableViews>
-        <Button
-          size="small"
-          sx={{
-            position: 'absolute',
-            top: '50%',
-            left: 8,
-            transform: 'translateY(-50%)',
-            minWidth: 'auto',
-            backgroundColor: 'rgba(250, 250, 250, 0.2)',
-          }}
-          onClick={handleBack}
-          disabled={activeStep === 0}
-        >
-          <KeyboardArrowLeft />
-        </Button>
-        <Button
-          size="small"
-          sx={{
-            position: 'absolute',
-            top: '50%',
-            right: 8,
-            transform: 'translateY(-50%)',
-            minWidth: 'auto',
-            backgroundColor: 'rgba(250, 250, 250, 0.2)',
-          }}
-          onClick={handleNext}
-          disabled={activeStep === maxSteps - 1}
-        >
-          <KeyboardArrowRight />
-        </Button>
+        </Slider>
       </Box>
       <Box
         sx={{


### PR DESCRIPTION
**Este PR actualiza el carrusel de fotos utilizado en la sección de publicaciones. El cambio se debe a la deprecación del carrusel anterior, y se ha optado por utilizar una nueva librería que proporciona una mejor estabilidad y soporte continuo.**

**Cambios Realizados**

**Sustitución del Carrusel de Fotos:**
Se reemplazó la importación de SwipeableViews debido a su deprecación.

**Nueva Librería para Carrusel:**
Se importaron los estilos necesarios para el carrusel de slick-carousel:
"slick-carousel/slick/slick.css"
"slick-carousel/slick/slick-theme.css"

**Estabilidad y Mantenimiento:**
La nueva librería de carrusel (slick-carousel) es una solución más robusta y mantiene un soporte activo, asegurando la estabilidad de la aplicación en el futuro.

**El propósito de este cambio es mejorar la estabilidad y mantenibilidad del carrusel de fotos en la sección de publicaciones, utilizando una librería moderna y con soporte continuo. Esta actualización garantiza que el carrusel funcione sin problemas y que la aplicación no dependa de una librería deprecada.**

**_[ Miguel Ortiz ]-[ Junior Front-End Developer ]_**